### PR TITLE
Ghidra symbols analysis

### DIFF
--- a/ghidra/scripts/M68kMacSymbols.java
+++ b/ghidra/scripts/M68kMacSymbols.java
@@ -29,8 +29,9 @@ public class M68kMacSymbols extends GhidraScript {
         for (Function func : currentProgram.getFunctionManager().getFunctionsNoStubs(true)) {
             for (Instruction inst : currentProgram.getListing().getInstructions(func.getBody(), true)) {
                 for (byte[] ending : ENDINGS) {
-                    if (Arrays.equals(ending, inst.getBytes())) {
-                        Address symbolAddr = inst.getAddress().addNoWrap(2);
+                    byte[] instructionBytes = inst.getBytes();
+                    if (Arrays.equals(ending, Arrays.copyOfRange(instructionBytes, 0, 2))) { // take first 2 bytes only
+                        Address symbolAddr = inst.getAddress().addNoWrap(instructionBytes.length);
                         int length = getByte(symbolAddr) & 0xff;
                         symbolAddr = symbolAddr.addNoWrap(1);
                         if (length == 0x80) {

--- a/ghidra/scripts/M68kMacSymbols.java
+++ b/ghidra/scripts/M68kMacSymbols.java
@@ -47,15 +47,20 @@ public class M68kMacSymbols extends GhidraScript {
                         byte[] symbolBytes = getBytes(symbolAddr, length);
                         if (length > 0) {
                             boolean goodSymbol = true;
-                            for (byte b : symbolBytes) {
-                                int i = (int)b & 0xff;
-                                if (i < 32 || i > 126) {
-                                    goodSymbol = false;
+                            for (int i = 0; i < symbolBytes.length; i++) {
+                                int val = symbolBytes[i] & 0xff;
+                                if (val < 32 || val > 126) {
+                                    // Last char might be unprintable (Symantec C++ bug), omit it
+                                    if (i == symbolBytes.length - 1) {
+                                        length--;
+                                    } else {
+                                        goodSymbol = false;
+                                    }
                                     break;
                                 }
                             }
                             if (goodSymbol) {
-                                String symbol = new String(symbolBytes);
+                                String symbol = new String(getBytes(symbolAddr, length));
                                 symbol = symbol.replace(" ", "_");
                                 func.setName(symbol, SourceType.ANALYSIS);
                             }


### PR DESCRIPTION
Here are some improvements to debug symbols analysis for the Ghidra script.

**Fixed rtd instruction logic**
We cannot assume `rtd` instruction is only 2 bytes long. All of the examples I have found also have a 2 byte immediate value ie. `rtd #immediate`. So we can identify the `rtd` using the first 2 bytes, but then we need to use the actual length of the instruction to calculate `symbolAddr`.

**Handling for buggy Symantec symbol length**
Some versions of the Think/Symantec compiler have a bug where the indicated symbol length and the actual count of symbol chars do not match. I was able to replicate the bug at least on Symantec C++ 7.0:
<img width="245" alt="symbols" src="https://github.com/user-attachments/assets/25f6bfb3-9134-4457-b6c9-656d10c41ac5" />
At offset `0x274` there's a `rts` instruction (4E75). After that theres byte `0x80` meaning that the length is in the next byte `0x23` == 35 decimal. If we count the chars in the highlighted symbol name, we get only 34, so the length is off by one. My fix is to shorten the symbol name by one if the char at the last position (`0x00` in the example above) is unprintable. 